### PR TITLE
CSV Export fix

### DIFF
--- a/application/controllers/single_page/dashboard/reports/forms.php
+++ b/application/controllers/single_page/dashboard/reports/forms.php
@@ -114,8 +114,8 @@ class Forms extends DashboardPageController
                         $row[] = mb_convert_encoding($answerSet['answers'][$questionId]['answer'], $encoding) . mb_convert_encoding($answerSet['answers'][$questionId]['answerLong'], $encoding);
                     }
                 }
+                fputcsv($fp, $row);
             }
-            fputcsv($fp, $row);
             
             rewind($fp);
             if ($encoding =="SJIS") {
@@ -190,8 +190,8 @@ class Forms extends DashboardPageController
                         $row[] = $answerSet['answers'][$questionId]['answer'] . $answerSet['answers'][$questionId]['answerLong'];
                     }
                 }
+                fputcsv($fp, $row);
             }
-            fputcsv($fp, $row);
             fclose($fp);
             die;
         }

--- a/application/controllers/single_page/dashboard/reports/forms.php
+++ b/application/controllers/single_page/dashboard/reports/forms.php
@@ -108,7 +108,7 @@ class Forms extends DashboardPageController
                             $fileVersion = $file->getApprovedVersion();
                             $row[] = $fileVersion->getDownloadURL();
                         } else {
-                            $row[] = t('File not found');
+                            $row[] = mb_convert_encoding(t('File not found'), $encoding);
                         }
                     } else {
                         $row[] = mb_convert_encoding($answerSet['answers'][$questionId]['answer'], $encoding) . mb_convert_encoding($answerSet['answers'][$questionId]['answerLong'], $encoding);


### PR DESCRIPTION
CSV出力処理の以下の2点について修正させていただきました。
- 複数データを出力した際に最後の1件しか出力されない
  80行〜、156行〜のforeachループの先頭で`$row`が都度初期化されていることが原因と思いましたので、`fputcsv($fp, $row)`をforeachループ内に移動しました。
- ファイル添付フィールドのメッセージ修正
  ファイルを添付しなかった場合に表示されるテキストが文字化けしていました。

よろしくお願いします。
